### PR TITLE
Change /index to /home

### DIFF
--- a/src/components/LandingPage/LandingPage.jsx
+++ b/src/components/LandingPage/LandingPage.jsx
@@ -31,7 +31,7 @@ export default function LandingPage({user}) {
                         <img src={logo} alt="logo" />
                     </div>
                     <div className="enterButton">
-                        <Link className="landingButton" to="/remote-learning"><span>{t("landing.enter")}</span></Link>
+                        <Link className="landingButton" to="/home"><span>{t("landing.enter")}</span></Link>
                         {user? <Link className="landingButton" to="/student/home"><span>{t("landing.home")}</span></Link>:
                          <Link className="landingButton" to="/login"><span>{t("landing.login")}</span></Link>}
                        

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -34,7 +34,7 @@ const NavBar = ({ page, user, header = null }) => {
     const { t, i18n } = useTranslation();
     const [pages, setPages] = useState(
         {
-            'Home': { path: '/index', parentPage: null },
+            'Home': { path: '/home', parentPage: null },
             'About': { path: '/about', parentPage: null },
             'Contact': { path: '/contact', parentPage: null },
             'Partners': { path: '/partners', parentPage: null },

--- a/src/components/Site/Site.jsx
+++ b/src/components/Site/Site.jsx
@@ -26,7 +26,7 @@ const Site = ({ user,setUser }) => {
     let { path, url } = useRouteMatch();
     return (
         <div>
-            <Route path='/index' exact>
+            <Route path='/home' exact>
                 <NavBar page='Home' user={user}></NavBar>
                 <HomePage></HomePage>
             </Route>


### PR DESCRIPTION
Issue   : can't access home page via direct path, eg."bpgolfacademy.com/index"

Cause : the browser automatically parses ".../index" to its domain name, which is pointing to the landing page.

Fix.      : replace "/index" with "/home"